### PR TITLE
Updates stemming from the upcoming release of details

### DIFF
--- a/user-guide/fixtures.md
+++ b/user-guide/fixtures.md
@@ -9,7 +9,7 @@ A fixture is a pre-defined, reusable test abstraction. The objects under test ar
 
 To get a better understanding of fixtures, imagine a regular test file, but the object (or objects) under test can be swapped so that the same standardized test implementation can be used against multiple objects.
 
-A fixture is just a plain old Ruby object that includes the TestBench API. A fixture has access to the same API that any TestBench test would. By including the `TestBench::Fixture` module into a Ruby object, the object acquires all of the methods available to a test script, including `context`, `test`, `assert`, `refute`, `assert_raises`, `refute_raises`, and `comment`.
+A fixture is just a plain old Ruby object that includes the TestBench API. A fixture has access to the same API that any TestBench test would. By including the `TestBench::Fixture` module into a Ruby object, the object acquires all of the methods available to a test script, including `context`, `test`, `assert`, `refute`, `assert_raises`, `refute_raises`, `comment`, and `detail`.
 
 ## Fixture API
 

--- a/user-guide/running-tests.md
+++ b/user-guide/running-tests.md
@@ -129,7 +129,7 @@ Executing `bench` the `--help` or `-h` switches will print descriptions of the s
 
 ``` bash
 > bench --help
-Usage: ./script/bench [options] [paths]
+Usage: bench [options] [paths]
 
 Informational Options
     -h, --help                       Print this help message and exit successfully

--- a/user-guide/running-tests.md
+++ b/user-guide/running-tests.md
@@ -129,7 +129,7 @@ Executing `bench` the `--help` or `-h` switches will print descriptions of the s
 
 ``` bash
 > bench --help
-Usage: bench [options] [paths]
+Usage: ./script/bench [options] [paths]
 
 Informational Options
     -h, --help                       Print this help message and exit successfully
@@ -137,16 +137,17 @@ Informational Options
 
 Configuration Options
     -a, --[no-]abort-on-error        Exit immediately after any test failure or error (Default: off)
+    -d, --[no-]detail [DETAIL]       Always show (or hide) details (Default: failure)
     -x, --[no-]exclude PATTERN       Do not execute test files matching PATTERN (Default: /_init.rb$/)
+    -l, --log-level LEVEL            Set the internal logging level to LEVEL (Default: fatal)
     -o PATTERN,                      Omit backtrace frames matching PATTERN (Default: /test_bench/)
         --[no-]omit-backtrace
-    -l [none|summary|failure|pass|debug],
-        --output-level               Sets output level (Default: pass)
     -s [on|off|detect],              Render output coloring and font styling escape codes (Default: detect)
         --output-styling
     -p                               Do not fail the test run if there are deactivated tests or contexts, e.g. _test or _context (Default: off)
         --[no-]permit-deactivated-tests
     -r, --[no-]reverse-backtraces    Reverse order of backtraces when printing errors (Default: off)
+    -v, --[no-]verbose               Increase output verbosity (Default: off)
 
 Paths to test files (and directories containing test files) can be given after any command line arguments or via STDIN (or both).
 If no paths are given, a default path (test/automated) is scanned for test files.
@@ -154,12 +155,13 @@ If no paths are given, a default path (test/automated) is scanned for test files
 The following environment variables can also control execution:
 
     TEST_BENCH_ABORT_ON_ERROR          Same as -a or --abort-on-error
+    TEST_BENCH_DETAIL                  Same as -d or --detail
     TEST_BENCH_EXCLUDE_FILE_PATTERN    Same as -x or --exclude-file-pattern
+    TEST_BENCH_LOG_LEVEL               Same as -l or --log-level
     TEST_BENCH_OMIT_BACKTRACE_PATTERN  Same as -o or --omit-backtrace-pattern
-    TEST_BENCH_OUTPUT_LEVEL            Same as -l or --output-level
     TEST_BENCH_OUTPUT_STYLING          Same as -s or --output-styling
     TEST_BENCH_FAIL_DEACTIVATED_TESTS  Opposite of -p or --permit-deactivated-tests
     TEST_BENCH_REVERSE_BACKTRACES      Same as -r or --reverse-backtraces
+    TEST_BENCH_VERBOSE                 Same as -v or --reverse-backtraces
 
-Finally, the VERBOSE environment variable can set the output level to debug. If given, VERBOSE will take precedence over TEST_BENCH_OUTPUT_STYLING.
 ```

--- a/user-guide/writing-tests.md
+++ b/user-guide/writing-tests.md
@@ -152,10 +152,14 @@ When tests fail, it is often necessary to see details of the test scenario itsel
 context "Some Context" do
   test "Passing test" do
     detail "Will not be printed"
+
+    assert(true)
   end
 
   test "Failing test" do
     detail "Will be printed"
+
+    assert(false)
   end
 end
 ```


### PR DESCRIPTION
- In "Writing Tests," replaced the block-form assertion section with a section about creating higher level assertions (using details to convey important data on failure)
- Also in "Writing Tests," added a section for Detail just under Comment
- In "Runnig Tests," updated the print-out of `bench --help`
- Include `detail` in lists of the core TestBench DSL methods

I'm not very happy with the Detail section, but am not yet sure how to best document `detail` on its own. I replaced 